### PR TITLE
Fix test dependency on test executable

### DIFF
--- a/parseargs.cabal
+++ b/parseargs.cabal
@@ -34,6 +34,7 @@ Test-Suite test-parseargs
   Type:            exitcode-stdio-1.0
   Main-Is:         test-parseargs.hs
   build-depends:   base < 5, process < 2
+  build-tool-depends: parseargs:parseargs-example
 
 Source-repository head
   Type:     git

--- a/test-parseargs.sh
+++ b/test-parseargs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright © 2016 Bart Massey
 # Run simple parseargs tests
-PA=dist/build/parseargs-example/parseargs-example
+PA=parseargs-example
 TMP=/tmp/test-parseargs-$$
 trap "rm -f $TMP" 0 1 2 3 15
 for f in tests/*.in


### PR DESCRIPTION
This fixes tests for `cabal build`, `cabal new-build` and Stack.